### PR TITLE
Cleanup bibliography

### DIFF
--- a/example.bib
+++ b/example.bib
@@ -1,39 +1,29 @@
-
-@electronic{smmtt,
-   title = {RISC-V Supervisor Domains Access Protection},
-   url = {https://github.com/riscv/riscv-smmtt}
-}
 @electronic{hti,
-   title = {RISC-V Hart-Trace Interface (RHTI)},
-   url = {https://github.com/riscv-non-isa/hart-trace-interface/}
- }
+  title = {RISC-V Hart-Trace Interface (RHTI)},
+  url = {https://github.com/riscv-non-isa/riscv-hart-trace-interface}
+}
 
 @electronic{etrace,
-   title = {RISC-V Efficient Trace for RISC-V},
-   url = {https://github.com/riscv-non-isa/riscv-trace-spec}
- }
+  title = {RISC-V Efficient Trace for RISC-V},
+  url = {https://github.com/riscv-non-isa/riscv-trace-spec}
+}
 
 @electronic{ntrace,
-   title = {RISC-V N-Trace (Nexus-based Trace) Specification},
-   url = {https://github.com/riscv-non-isa/tg-nexus-trace}
- }
+  title = {RISC-V N-Trace (Nexus-based Trace) Specification},
+  url = {https://github.com/riscv-non-isa/riscv-nexus-trace}
+}
 
- @electronic{dbgspec,
+@electronic{dbgspec,
   title = {RISC-V Debug Specification},
-   url = {https://github.com/riscv/riscv-debug-spec}
- }
+  url = {https://github.com/riscv/riscv-debug-spec}
+}
 
- @electronic{iopmp,
+@electronic{iopmp,
   title = {RISC-V IOPMP Architecture Specification},
-   url = {https://github.com/riscv-non-isa/iopmp-spec/releases}
- }
+  url = {https://github.com/riscv-non-isa/riscv-iopmp}
+}
 
- @electronic{worlds,
+@electronic{worlds,
   title = {RISC-V Worlds},
-   url = {https://github.com/riscv/riscv-worlds}
- }
-
-  @electronic{smstateen,
-  title = {RISC-V State Enable Extension},
-   url = {https://github.com/riscvarchive/riscv-state-enable}
- }
+  url = {https://github.com/riscv/riscv-worlds}
+}


### PR DESCRIPTION
- Update stale URLs of RHTI, N-Trace and IOPMP.
- Remove smmtt and smstateen which are no longer referenced.